### PR TITLE
docs: Add required federation annotation to ServiceExport documentation

### DIFF
--- a/docs/api-types/service-export.md
+++ b/docs/api-types/service-export.md
@@ -20,6 +20,9 @@ instead AWS Gateway API Controller uses its own version of the resource for the 
 
 ### Annotations
 
+* `application-networking.k8s.aws/federation` (required)  
+  Must be set to `amazon-vpc-lattice` to enable federation functionality. Without this annotation, the ServiceExport resource will not work.
+
 * `application-networking.k8s.aws/port`  
   Represents which port of the exported Service will be used.
   When a comma-separated list of ports is provided, the traffic will be distributed to all ports in the list.
@@ -33,6 +36,7 @@ kind: ServiceExport
 metadata:
   name: service-1
   annotations:
+    application-networking.k8s.aws/federation: "amazon-vpc-lattice"
     application-networking.k8s.aws/port: "9200"
 spec: {}
 ```


### PR DESCRIPTION
### Issue
Fixes aws/aws-application-networking-k8s#688

### Description
Adds documentation for the required `application-networking.k8s.aws/federation` annotation in the ServiceExport API reference. This annotation must be set to `amazon-vpc-lattice` for ServiceExport resources to work properly.

### Changes Made
- Added documentation for the required federation annotation in the Annotations section
- Updated example configuration to include the federation annotation

### Testing Done
- Reviewed documentation changes for accuracy and clarity

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.