### PR TITLE
docs: Add federation annotation documentation for ServiceExport

### DIFF
--- a/docs/api-types/service-export.md
+++ b/docs/api-types/service-export.md
@@ -20,6 +20,10 @@ instead AWS Gateway API Controller uses its own version of the resource for the 
 
 ### Annotations
 
+* `application-networking.k8s.aws/federation`  
+  Required annotation that must be set to `amazon-vpc-lattice` to enable federation functionality.
+  Without this annotation, the ServiceExport resource will not work.
+
 * `application-networking.k8s.aws/port`  
   Represents which port of the exported Service will be used.
   When a comma-separated list of ports is provided, the traffic will be distributed to all ports in the list.
@@ -33,6 +37,7 @@ kind: ServiceExport
 metadata:
   name: service-1
   annotations:
+    application-networking.k8s.aws/federation: "amazon-vpc-lattice"
     application-networking.k8s.aws/port: "9200"
 spec: {}
 ```


### PR DESCRIPTION
Fixes aws/aws-application-networking-k8s#690

Add documentation for the required `application-networking.k8s.aws/federation` annotation in ServiceExport resource. This annotation must be set to `amazon-vpc-lattice` for the ServiceExport resource to work properly.

Changes made:
1. Added documentation for the federation annotation in the Annotations section
2. Updated the example configuration to include the required annotation

This helps users understand that the annotation is required and prevents confusion when ServiceExport resources don't work as expected.